### PR TITLE
Don't reuse node after 429 and 403 responses

### DIFF
--- a/packages/cosmos/src/client/node_chooser.rs
+++ b/packages/cosmos/src/client/node_chooser.rs
@@ -33,7 +33,6 @@ impl NodeChooser {
 
     pub(super) fn choose_node(&self) -> Result<&Node, ConnectionError> {
         let primary_health = self.primary.is_healthy(self.allowed_error_count);
-        println!("{primary_health:?}");
         if primary_health.is_healthy() {
             Ok(&self.primary)
         } else {

--- a/packages/cosmos/src/client/pool.rs
+++ b/packages/cosmos/src/client/pool.rs
@@ -47,7 +47,7 @@ impl Pool {
             .await
             .expect("Pool::get: semaphore has been closed");
 
-        let node = self.node_chooser.choose_node();
+        let node = self.node_chooser.choose_node()?;
         Ok(NodeGuard {
             inner: node.clone(),
             _permit: permit,


### PR DESCRIPTION
This helps avoid creating a cascading failure of rate limiting.