### PR TITLE
perform_query follows the builder pattern

### DIFF
--- a/packages/cosmos/src/authz.rs
+++ b/packages/cosmos/src/authz.rs
@@ -40,7 +40,8 @@ impl Cosmos {
                 mut grants,
                 pagination: pag_res,
             } = self
-                .perform_query(req, Action::QueryGranterGrants(granter.get_address()), true)
+                .perform_query(req, Action::QueryGranterGrants(granter.get_address()))
+                .run()
                 .await?
                 .into_inner();
             println!("{grants:?}");

--- a/packages/cosmos/src/contract.rs
+++ b/packages/cosmos/src/contract.rs
@@ -224,8 +224,8 @@ impl Contract {
                     contract: self.address,
                     key: key.into(),
                 },
-                true,
             )
+            .run()
             .await?
             .into_inner()
             .data)
@@ -261,8 +261,8 @@ impl Contract {
                     contract: self.address,
                     message: msg.into(),
                 },
-                true,
             )
+            .run()
             .await?
             .into_inner();
         Ok(res.data)
@@ -294,8 +294,8 @@ impl Contract {
                     query_data: msg,
                 },
                 action.clone(),
-                true,
             )
+            .run()
             .await?
             .into_inner();
         serde_json::from_slice(&res.data).map_err(|source| crate::Error::JsonDeserialize {
@@ -341,8 +341,8 @@ impl Contract {
                     address: self.address.into(),
                 },
                 action.clone(),
-                true,
             )
+            .run()
             .await?
             .into_inner()
             .contract_info
@@ -362,8 +362,8 @@ impl Contract {
                     pagination: None,
                 },
                 Action::ContractHistory(self.address),
-                true,
             )
+            .run()
             .await?
             .into_inner())
     }

--- a/packages/cosmos/src/osmosis.rs
+++ b/packages/cosmos/src/osmosis.rs
@@ -23,26 +23,20 @@ impl Cosmos {
     ///
     /// Note that this query will fail if called on chains besides Osmosis Mainnet.
     pub async fn get_osmosis_epoch_info(&self) -> Result<EpochsInfo, QueryError> {
-        self.perform_query(
-            epochs::QueryEpochsInfoRequest {},
-            Action::OsmosisEpochsInfo,
-            true,
-        )
-        .await
-        .map(|res| EpochsInfo {
-            epochs: res.into_inner().epochs,
-        })
+        self.perform_query(epochs::QueryEpochsInfoRequest {}, Action::OsmosisEpochsInfo)
+            .run()
+            .await
+            .map(|res| EpochsInfo {
+                epochs: res.into_inner().epochs,
+            })
     }
     /// Get the Osmosis txfees information.
     ///
     /// Note that this query will fail if called on chains besides Osmosis Mainnet.
     pub async fn get_osmosis_txfees_info(&self) -> Result<TxFeesInfo, Error> {
         let eip_base_fee = self
-            .perform_query(
-                txfees::QueryEipBaseFeeRequest {},
-                Action::OsmosisTxFeesInfo,
-                true,
-            )
+            .perform_query(txfees::QueryEipBaseFeeRequest {}, Action::OsmosisTxFeesInfo)
+            .run()
             .await
             .map(|res| res.into_inner())?;
 


### PR DESCRIPTION
Will make it easier to add additional config to the method of performing a query.