### PR TITLE
Node chooser returns a list of nodes

### DIFF
--- a/packages/cosmos/src/client/node.rs
+++ b/packages/cosmos/src/client/node.rs
@@ -231,7 +231,10 @@ impl Node {
         SingleNodeHealthReport {
             grpc_url: self.node_inner.grpc_url.clone(),
             is_fallback: self.node_inner.is_fallback,
-            node_health_level: self.node_health_level(),
+            node_health_level: last_error
+                .map_or(NodeHealthLevel::Unblocked { error_count: 0 }, |x| {
+                    x.node_health_level()
+                }),
             error_count: last_error.map_or(0, |last_error| last_error.error_count),
             last_error: last_error.map(|last_error| {
                 let error = match &last_error.action {

--- a/packages/cosmos/src/client/pool.rs
+++ b/packages/cosmos/src/client/pool.rs
@@ -2,15 +2,9 @@ use std::sync::Arc;
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-use crate::{
-    error::{BuilderError, ConnectionError},
-    CosmosBuilder,
-};
+use crate::{error::BuilderError, CosmosBuilder};
 
-use super::{
-    node::Node,
-    node_chooser::{AllNodes, NodeChooser},
-};
+use super::node_chooser::{AllNodes, NodeChooser};
 
 #[derive(Clone)]
 pub(super) struct Pool {
@@ -18,17 +12,6 @@ pub(super) struct Pool {
     pub(super) node_chooser: NodeChooser,
     /// Permits for enforcing global concurrent request count.
     semaphore: Arc<Semaphore>,
-}
-
-pub(super) struct NodeGuard {
-    pub(super) inner: Node,
-    _permit: OwnedSemaphorePermit,
-}
-
-impl NodeGuard {
-    pub(crate) fn get_inner_mut(&mut self) -> &mut Node {
-        &mut self.inner
-    }
 }
 
 impl Pool {
@@ -42,59 +25,15 @@ impl Pool {
         })
     }
 
-    pub(super) async fn get(&self) -> Result<NodeGuard, ConnectionError> {
-        let permit = self
-            .semaphore
+    pub(super) fn all_nodes(&self) -> AllNodes {
+        self.node_chooser.all_nodes()
+    }
+
+    pub(crate) async fn get_node_permit(&self) -> OwnedSemaphorePermit {
+        self.semaphore
             .clone()
             .acquire_owned()
             .await
-            .expect("Pool::get: semaphore has been closed");
-
-        let node = self.node_chooser.choose_node()?;
-        Ok(NodeGuard {
-            inner: node.clone(),
-            _permit: permit,
-        })
-    }
-
-    pub(super) fn all_nodes(&self) -> AllNodeGuards {
-        AllNodeGuards {
-            pool: self,
-            all_nodes: self.node_chooser.all_nodes(),
-        }
-    }
-
-    pub(crate) async fn get_with_node(&self, node: &Node) -> Result<NodeGuard, ConnectionError> {
-        let permit = self
-            .semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("Pool::get_with_node: semaphore has been closed");
-
-        Ok(NodeGuard {
-            inner: node.clone(),
-            _permit: permit,
-        })
-    }
-}
-
-pub(crate) struct AllNodeGuards<'a> {
-    pool: &'a Pool,
-    all_nodes: AllNodes<'a>,
-}
-
-impl AllNodeGuards<'_> {
-    pub(crate) async fn next(&mut self) -> Option<NodeGuard> {
-        let inner = self.all_nodes.next()?.clone();
-        let _permit = self
-            .pool
-            .semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("AllNodeGuards::next: semaphore has been closed");
-
-        Some(NodeGuard { inner, _permit })
+            .expect("Pool::get_with_node: semaphore has been closed")
     }
 }

--- a/packages/cosmos/src/client/query.rs
+++ b/packages/cosmos/src/client/query.rs
@@ -38,7 +38,7 @@ pub(crate) trait GrpcRequest: Clone + Sized + Send + 'static {
 
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status>;
 }
 
@@ -47,7 +47,7 @@ impl GrpcRequest for QueryAccountRequest {
     type Response = QueryAccountResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.auth_query_client().account(req).await
     }
@@ -58,7 +58,7 @@ impl GrpcRequest for QueryAllBalancesRequest {
     type Response = QueryAllBalancesResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.bank_query_client().all_balances(req).await
     }
@@ -69,7 +69,7 @@ impl GrpcRequest for QuerySmartContractStateRequest {
     type Response = QuerySmartContractStateResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().smart_contract_state(req).await
     }
@@ -80,7 +80,7 @@ impl GrpcRequest for QueryRawContractStateRequest {
     type Response = QueryRawContractStateResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().raw_contract_state(req).await
     }
@@ -91,7 +91,7 @@ impl GrpcRequest for QueryCodeRequest {
     type Response = QueryCodeResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().code(req).await
     }
@@ -102,7 +102,7 @@ impl GrpcRequest for GetTxRequest {
     type Response = GetTxResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().get_tx(req).await
     }
@@ -113,7 +113,7 @@ impl GrpcRequest for GetTxsEventRequest {
     type Response = GetTxsEventResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().get_txs_event(req).await
     }
@@ -124,7 +124,7 @@ impl GrpcRequest for QueryContractInfoRequest {
     type Response = QueryContractInfoResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().contract_info(req).await
     }
@@ -135,7 +135,7 @@ impl GrpcRequest for QueryContractHistoryRequest {
     type Response = QueryContractHistoryResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.wasm_query_client().contract_history(req).await
     }
@@ -146,7 +146,7 @@ impl GrpcRequest for GetBlockByHeightRequest {
     type Response = GetBlockByHeightResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tendermint_client().get_block_by_height(req).await
     }
@@ -157,7 +157,7 @@ impl GrpcRequest for GetLatestBlockRequest {
     type Response = GetLatestBlockResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tendermint_client().get_latest_block(req).await
     }
@@ -168,7 +168,7 @@ impl GrpcRequest for SimulateRequest {
     type Response = SimulateResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().simulate(req).await
     }
@@ -179,7 +179,7 @@ impl GrpcRequest for BroadcastTxRequest {
     type Response = BroadcastTxResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.tx_service_client().broadcast_tx(req).await
     }
@@ -190,7 +190,7 @@ impl GrpcRequest for QueryGranterGrantsRequest {
     type Response = QueryGranterGrantsResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.authz_query_client().granter_grants(req).await
     }
@@ -201,7 +201,7 @@ impl GrpcRequest for QueryGranteeGrantsRequest {
     type Response = QueryGranteeGrantsResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.authz_query_client().grantee_grants(req).await
     }
@@ -212,7 +212,7 @@ impl GrpcRequest for QueryEpochsInfoRequest {
     type Response = QueryEpochsInfoResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.epochs_query_client().epoch_infos(req).await
     }
@@ -223,7 +223,7 @@ impl GrpcRequest for QueryEipBaseFeeRequest {
     type Response = QueryEipBaseFeeResponse;
     async fn perform(
         req: tonic::Request<Self>,
-        inner: &mut Node,
+        inner: &Node,
     ) -> Result<tonic::Response<Self::Response>, tonic::Status> {
         inner.txfees_query_client().get_eip_base_fee(req).await
     }

--- a/packages/cosmos/src/cosmos_builder.rs
+++ b/packages/cosmos/src/cosmos_builder.rs
@@ -32,14 +32,13 @@ pub struct CosmosBuilder {
     connection_timeout: Option<Duration>,
     idle_timeout_seconds: Option<u32>,
     query_timeout_seconds: Option<u32>,
-    query_retries: Option<u32>,
+    query_retries: Option<usize>,
     block_lag_allowed: Option<u32>,
     latest_block_age_allowed: Option<Duration>,
     fallback_timeout: Option<Duration>,
     pub(crate) chain_paused_method: ChainPausedMethod,
     pub(crate) autofix_simulate_sequence_mismatch: Option<bool>,
     dynamic_gas_retries: Option<u32>,
-    allowed_error_count: Option<usize>,
     osmosis_gas_params: Option<OsmosisGasParams>,
     osmosis_gas_price_too_old_seconds: Option<u64>,
     max_price: Option<f64>,
@@ -84,7 +83,6 @@ impl CosmosBuilder {
             chain_paused_method: ChainPausedMethod::None,
             autofix_simulate_sequence_mismatch: None,
             dynamic_gas_retries: None,
-            allowed_error_count: None,
             osmosis_gas_params: None,
             osmosis_gas_price_too_old_seconds: None,
             max_price: None,
@@ -315,12 +313,12 @@ impl CosmosBuilder {
     /// Only retries if there is a tonic-level error.
     ///
     /// Defaults to 3
-    pub fn query_retries(&self) -> u32 {
+    pub fn query_retries(&self) -> usize {
         self.query_retries.unwrap_or(3)
     }
 
     /// See [Self::query_retries]
-    pub fn set_query_retries(&mut self, query_retries: Option<u32>) {
+    pub fn set_query_retries(&mut self, query_retries: Option<usize>) {
         self.query_retries = query_retries;
     }
 
@@ -386,18 +384,6 @@ impl CosmosBuilder {
     /// See [Self::autofix_sequence_mismatch]
     pub fn set_autofix_sequence_mismatch(&mut self, autofix_sequence_mismatch: Option<bool>) {
         self.autofix_simulate_sequence_mismatch = autofix_sequence_mismatch;
-    }
-
-    /// How many network errors in a row are allowed before we consider a node unhealthy?
-    ///
-    /// Default: 3
-    pub fn get_allowed_error_count(&self) -> usize {
-        self.allowed_error_count.unwrap_or(3)
-    }
-
-    /// See [Self::get_allowed_error_count]
-    pub fn set_allowed_error_count(&mut self, allowed: Option<usize>) {
-        self.allowed_error_count = allowed;
     }
 
     /// Set parameters for Osmosis's EIP fee market gas.


### PR DESCRIPTION
This ended up being a much larger refactoring than I initially anticipated. The overall goal is simple though: instead of randomly choosing nodes, potentially rechoosing the same nodes multiple times for a single query, get a full list of nodes and try them sequentially.

This ended up having a bunch of add-on impacts in the code, such as identifying that the simulation and broadcast sequence tracking information should be Cosmos-wide instead of at the Node level.

Additionally, the logic around all-nodes broadcast is slightly better now. If any of the broadcasts succeed, we will use it, even if broadcasting on selected nodes failed.