### PR TITLE
Remove the build with sanity check method

### DIFF
--- a/packages/cosmos/src/clap.rs
+++ b/packages/cosmos/src/clap.rs
@@ -126,7 +126,7 @@ impl CosmosOpt {
     pub async fn build(self) -> Result<Cosmos, CosmosOptError> {
         self.into_builder()
             .await?
-            .build_lazy()
+            .build()
             .map_err(|source| CosmosOptError::CosmosBuilderError { source })
     }
 }

--- a/packages/cosmos/src/client.rs
+++ b/packages/cosmos/src/client.rs
@@ -1824,14 +1824,12 @@ mod tests {
     }
 
     #[tokio::test]
-
     async fn lazy_load() {
         let mut builder = CosmosNetwork::OsmosisTestnet.builder().await.unwrap();
         builder.set_query_retries(Some(0));
         // something that clearly won't work
         builder.set_grpc_url("https://0.0.0.0:0".to_owned());
 
-        builder.clone().build().unwrap_err();
         let cosmos = builder.build().unwrap();
         cosmos.get_latest_block_info().await.unwrap_err();
     }

--- a/packages/cosmos/src/client.rs
+++ b/packages/cosmos/src/client.rs
@@ -646,39 +646,10 @@ pub(crate) struct SequenceInformation {
 }
 
 impl CosmosBuilder {
-    /// Create a new [Cosmos] and perform a sanity check to make sure the connection works.
-    pub async fn build(self) -> Result<Cosmos, BuilderError> {
-        let cosmos = self.build_lazy()?;
-
-        let resp = cosmos
-            .perform_query(GetLatestBlockRequest {}, Action::SanityCheck)
-            .no_retry()
-            .run()
-            .await
-            .map_err(|source| BuilderError::SanityQueryFailed { source })?;
-
-        let actual = resp
-            .into_inner()
-            .block
-            .and_then(|block| block.header)
-            .map(|header| header.chain_id);
-
-        let expected = cosmos.get_cosmos_builder().chain_id();
-        if actual.as_deref() == Some(expected) {
-            Ok(cosmos)
-        } else {
-            Err(BuilderError::MismatchedChainIds {
-                grpc_url: cosmos.get_cosmos_builder().grpc_url().to_owned(),
-                expected: expected.to_owned(),
-                actual,
-            })
-        }
-    }
-
     /// Create a new [Cosmos] but do not perform any sanity checks.
     ///
     /// Can fail if parsing the gRPC URLs fails.
-    pub fn build_lazy(self) -> Result<Cosmos, BuilderError> {
+    pub fn build(self) -> Result<Cosmos, BuilderError> {
         let builder = Arc::new(self);
         let chain_paused_status = builder.chain_paused_method.into();
         let gas_multiplier = builder.build_gas_multiplier();
@@ -1860,29 +1831,25 @@ mod tests {
         // something that clearly won't work
         builder.set_grpc_url("https://0.0.0.0:0".to_owned());
 
-        builder.clone().build().await.unwrap_err();
-        let cosmos = builder.build_lazy().unwrap();
+        builder.clone().build().unwrap_err();
+        let cosmos = builder.build().unwrap();
         cosmos.get_latest_block_info().await.unwrap_err();
     }
 
     #[tokio::test]
     async fn fallback() {
         let mut builder = CosmosNetwork::OsmosisTestnet.builder().await.unwrap();
-        // FIXME
-        // builder.set_allowed_error_count(Some(0));
         builder.add_grpc_fallback_url(builder.grpc_url().to_owned());
         builder.set_grpc_url("http://0.0.0.0:0");
-        let cosmos = builder.build_lazy().unwrap();
+        let cosmos = builder.build().unwrap();
         cosmos.get_latest_block_info().await.unwrap();
     }
 
     #[tokio::test]
     async fn ignore_broken_fallback() {
         let mut builder = CosmosNetwork::OsmosisTestnet.builder().await.unwrap();
-        // FIXME
-        // builder.set_allowed_error_count(Some(0));
         builder.add_grpc_fallback_url("http://0.0.0.0:0");
-        let cosmos = builder.build_lazy().unwrap();
+        let cosmos = builder.build().unwrap();
         cosmos.get_latest_block_info().await.unwrap();
     }
 

--- a/packages/cosmos/src/cosmos_network.rs
+++ b/packages/cosmos/src/cosmos_network.rs
@@ -69,7 +69,7 @@ impl CosmosNetwork {
 
     /// Convenience method to make a [Self::builder] and then [CosmosBuilder::build] it.
     pub async fn connect(self) -> Result<Cosmos, BuilderError> {
-        self.builder().await?.build().await
+        self.builder().await?.build()
     }
 
     /// Construct a [CosmosBuilder] for this network with default values.

--- a/packages/cosmos/src/error.rs
+++ b/packages/cosmos/src/error.rs
@@ -268,7 +268,6 @@ pub enum Action {
     ContractHistory(Address),
     GetEarliestBlock,
     WaitForTransaction(String),
-    SanityCheck,
     OsmosisEpochsInfo,
     OsmosisTxFeesInfo,
     StoreCode {
@@ -317,7 +316,6 @@ impl Display for Action {
             Action::ContractHistory(address) => write!(f, "contract history for {address}"),
             Action::GetEarliestBlock => f.write_str("get earliest block"),
             Action::WaitForTransaction(txhash) => write!(f, "wait for transaction {txhash}"),
-            Action::SanityCheck => f.write_str("sanity check"),
             Action::OsmosisEpochsInfo => f.write_str("get Osmosis epochs info"),
             Action::OsmosisTxFeesInfo => f.write_str("get Osmosis txfees info"),
             Action::StoreCode { txbuilder, txhash } => {


### PR DESCRIPTION
Something we discussed offline. The sanity checks will often cause false failures if the primary node is temporarily unavailable. (I just saw this occur for a production service.)

Very much open for discussion on this one, not sure it's the right approach.