### PR TITLE
cosmos-bin: Print transaction hash after migration is done

### DIFF
--- a/packages/cosmos-bin/src/contract.rs
+++ b/packages/cosmos-bin/src/contract.rs
@@ -224,9 +224,10 @@ pub(crate) async fn go(Opt { subcommand }: Opt, cosmos: Cosmos) -> Result<()> {
         } => {
             let address_type = cosmos.get_address_hrp();
             let contract = cosmos.make_contract(address);
-            contract
+            let tx = contract
                 .migrate_binary(&tx_opt.get_wallet(address_type)?, code_id, msg)
                 .await?;
+            println!("Transaction hash: {}", tx.txhash);
         }
         Subcommand::Execute {
             tx_opt,

--- a/packages/cosmos/src/contract.rs
+++ b/packages/cosmos/src/contract.rs
@@ -310,7 +310,7 @@ impl Contract {
         wallet: &Wallet,
         code_id: u64,
         msg: impl serde::Serialize,
-    ) -> Result<(), crate::Error> {
+    ) -> Result<TxResponse, crate::Error> {
         self.migrate_binary(wallet, code_id, serde_json::to_vec(&msg)?)
             .await
     }
@@ -321,15 +321,14 @@ impl Contract {
         wallet: &Wallet,
         code_id: u64,
         msg: impl Into<Vec<u8>>,
-    ) -> Result<(), crate::Error> {
+    ) -> Result<TxResponse, crate::Error> {
         let msg = MsgMigrateContract {
             sender: wallet.get_address_string(),
             contract: self.get_address_string(),
             msg: msg.into(),
             code_id,
         };
-        wallet.broadcast_message(&self.client, msg).await?;
-        Ok(())
+        wallet.broadcast_message(&self.client, msg).await
     }
 
     /// Get the contract info metadata


### PR DESCRIPTION
Motivation: Right now, it doesn't print anything which IMO is slightly confusing.

Unfortunately this changes the type signature of the publicly exposed methods.