### PR TITLE
Allow for configuration of code IDs

### DIFF
--- a/packages/cosmos-bin/src/config.rs
+++ b/packages/cosmos-bin/src/config.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use anyhow::Result;
-use cosmos::{AddressHrp, CosmosConfig, CosmosConfigError};
+use cosmos::{AddressHrp, ContractType, CosmosConfig, CosmosConfigError};
 
 #[derive(clap::Parser)]
 pub(crate) enum Opt {
@@ -45,6 +45,15 @@ pub(crate) enum Opt {
         name: String,
         /// gRPC URL
         url: String,
+    },
+    /// Add a recognized contract code ID
+    AddContract {
+        /// Network name
+        name: String,
+        /// Contract type
+        contract_type: ContractType,
+        /// Code ID
+        code_id: u64,
     },
 }
 
@@ -124,6 +133,17 @@ pub(crate) fn go(opt: crate::cli::Opt, inner: Opt) -> Result<()> {
         Opt::AddFallback { name, url } => {
             let mut config = load(&opt)?;
             config.add_grpc_fallback(name, url);
+            config.save()?;
+            println!("Changes saved");
+            Ok(())
+        }
+        Opt::AddContract {
+            name,
+            contract_type,
+            code_id,
+        } => {
+            let mut config = load(&opt)?;
+            config.add_contract(name, contract_type, code_id);
             config.save()?;
             println!("Changes saved");
             Ok(())

--- a/packages/cosmos/src/codeid.rs
+++ b/packages/cosmos/src/codeid.rs
@@ -151,3 +151,44 @@ impl HasAddressHrp for CodeId {
         self.client.get_address_hrp()
     }
 }
+
+/// A type of contract which is understood by this library.
+///
+/// This is used to allow configuring generally reusable contracts like CW3 multisigs.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    strum_macros::AsRefStr,
+    strum_macros::Display,
+    strum_macros::EnumString,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+#[non_exhaustive]
+pub enum ContractType {
+    /// CW3 flex multisig contract
+    Cw3Flex,
+    /// CW4 group contract
+    Cw4Group,
+}
+
+impl Cosmos {
+    /// Get the configured code ID for the given contract type.
+    ///
+    /// Returns an error if no such contract type is configured.
+    pub fn get_code_id_for(&self, contract_type: ContractType) -> crate::Result<u64> {
+        self.get_cosmos_builder()
+            .code_ids
+            .get(&contract_type)
+            .copied()
+            .ok_or(crate::Error::ContractTypeNotConfigured { contract_type })
+    }
+}

--- a/packages/cosmos/src/cosmos_builder.rs
+++ b/packages/cosmos/src/cosmos_builder.rs
@@ -1,9 +1,9 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use crate::{
     gas_multiplier::{GasMultiplier, GasMultiplierConfig},
     gas_price::GasPriceMethod,
-    AddressHrp, DynamicGasMultiplier,
+    AddressHrp, ContractType, DynamicGasMultiplier,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -50,6 +50,7 @@ pub struct CosmosBuilder {
     keep_alive_while_idle: Option<bool>,
     simulate_with_gas_coin: bool,
     delay_before_fallback: Option<tokio::time::Duration>,
+    pub(crate) code_ids: BTreeMap<ContractType, u64>,
 }
 
 impl CosmosBuilder {
@@ -96,6 +97,7 @@ impl CosmosBuilder {
             keep_alive_while_idle: None,
             simulate_with_gas_coin,
             delay_before_fallback: None,
+            code_ids: BTreeMap::new(),
         }
     }
 
@@ -153,6 +155,11 @@ impl CosmosBuilder {
     /// See [Self::hrp]
     pub fn set_hrp(&mut self, hrp: AddressHrp) {
         self.hrp = hrp;
+    }
+
+    /// Set a code ID for the given contract type.
+    pub fn set_code_id(&mut self, contract_type: ContractType, code_id: u64) {
+        self.code_ids.insert(contract_type, code_id);
     }
 
     /// Revert to the default gas multiplier value (static value of 1.3).

--- a/packages/cosmos/src/cosmos_network.rs
+++ b/packages/cosmos/src/cosmos_network.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, str::FromStr};
 use serde::de::Visitor;
 use strum_macros::{EnumString, IntoStaticStr};
 
-use crate::{error::BuilderError, gas_price::GasPriceMethod, Cosmos, CosmosBuilder, HasAddressHrp};
+use crate::{
+    error::BuilderError, gas_price::GasPriceMethod, ContractType, Cosmos, CosmosBuilder,
+    HasAddressHrp,
+};
 
 /// A set of known networks.
 ///
@@ -209,6 +212,30 @@ impl CosmosNetwork {
                 // https://github.com/cosmos/chain-registry/blob/master/injective/chain.json
                 builder.set_gas_price(500000000.0, 900000000.0);
             }
+        }
+
+        match self {
+            CosmosNetwork::OsmosisMainnet => {
+                builder.set_code_id(ContractType::Cw3Flex, 100);
+                builder.set_code_id(ContractType::Cw4Group, 101);
+            }
+            CosmosNetwork::OsmosisTestnet => {
+                builder.set_code_id(ContractType::Cw3Flex, 1519);
+                builder.set_code_id(ContractType::Cw4Group, 1521);
+            }
+            CosmosNetwork::SeiMainnet => {
+                builder.set_code_id(ContractType::Cw3Flex, 46);
+                builder.set_code_id(ContractType::Cw4Group, 47);
+            }
+            CosmosNetwork::InjectiveMainnet => {
+                builder.set_code_id(ContractType::Cw3Flex, 124);
+                builder.set_code_id(ContractType::Cw4Group, 125);
+            }
+            CosmosNetwork::NeutronMainnet => {
+                builder.set_code_id(ContractType::Cw3Flex, 1189);
+                builder.set_code_id(ContractType::Cw4Group, 1190);
+            }
+            _ => (),
         }
     }
 

--- a/packages/cosmos/src/error.rs
+++ b/packages/cosmos/src/error.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use cosmos_sdk_proto::cosmos::tx::v1beta1::OrderBy;
 use http::uri::InvalidUri;
 
-use crate::{Address, AddressHrp, CosmosBuilder, TxBuilder};
+use crate::{Address, AddressHrp, ContractType, CosmosBuilder, TxBuilder};
 
 /// Errors that can occur with token factory
 #[derive(thiserror::Error, Debug, Clone)]
@@ -344,6 +344,9 @@ pub enum Error {
     WasmGzipFailed {
         source: std::io::Error,
     },
+    ContractTypeNotConfigured {
+        contract_type: ContractType,
+    },
 }
 
 impl Display for Error {
@@ -410,6 +413,9 @@ impl Error {
             Error::Connection(e) => e.fmt_helper(f, pretty),
             Error::WasmGzipFailed { source } => {
                 write!(f, "Error during wasm Gzip compression: {source}")
+            }
+            Error::ContractTypeNotConfigured { contract_type } => {
+                write!(f, "Contract type not configured: {contract_type}")
             }
         }
     }

--- a/packages/cosmos/src/lib.rs
+++ b/packages/cosmos/src/lib.rs
@@ -2,7 +2,7 @@
 //! Library for communicating with Cosmos blockchains over gRPC
 pub use address::{Address, AddressHrp, HasAddress, HasAddressHrp, PublicKeyMethod, RawAddress};
 pub use client::{BlockInfo, Cosmos, CosmosTxResponse, HasCosmos};
-pub use codeid::CodeId;
+pub use codeid::{CodeId, ContractType};
 #[cfg(feature = "config")]
 pub use config::{CosmosConfig, CosmosConfigError};
 pub use contract::{Contract, ContractAdmin, HasContract};


### PR DESCRIPTION
This moves the handling of configured code IDs into the core library instead of the executable. Instead of simply hard-coding them, it uses the same configuration system as other values. This allows us to provide code IDs for custom networks or override the defaults.

This also adds CLI options for providing code IDs when generating a new CW3 flex contract.